### PR TITLE
Fix k-label detection and robustly map Wannier kx to DFT X grid in plot_bands

### DIFF
--- a/src/VaspPlot.jl
+++ b/src/VaspPlot.jl
@@ -113,7 +113,8 @@ function find_path_lengths(path_edges::Matrix{Float64}, klabels::Vector{String})
     path_lengths = zeros(length(klabels) - 1)
     d = 0
     for i in eachindex(path_lengths)
-        length(klabels[i]) > 1 && (d += 1)
+        # Only merged boundary labels like "A|B" skip one entry in path_edges.
+        occursin("|", klabels[i]) && (d += 1)
         path_lengths[i] = norm(path_edges[i+1+d, :] - path_edges[i+d, :])
     end
     return path_lengths
@@ -322,6 +323,18 @@ function plot_bands(bands;
         k_labels
     end
 
+    # If automatic label detection misses points, keep ticks readable
+    # by assigning deterministic fallback labels (K1, K2, ...).
+    if k_labels == [" "]
+        fallback_id = 1
+        for i in eachindex(klabels)
+            if isempty(strip(klabels[i]))
+                klabels[i] = "K$(fallback_id)"
+                fallback_id += 1
+            end
+        end
+    end
+
     E      = bands["E"]
     system = bands["system"]
     k_ind, klabels = merge_indices_and_labels(bands["k_ind"], klabels)
@@ -408,20 +421,33 @@ function plot_bands(bands;
         wann1 = wann_data isa Dict ? wann_data["up"]   : wann_data
         wann2 = wann_data isa Dict ? wann_data["down"] : wann_data
 
-        # Rescale Wannier kx (uniform [0,kmax]) onto the DFT X grid (non-uniform).
-        # Both paths share the same segment count; rescale each segment independently.
+        # Rescale Wannier kx onto the DFT X grid.
+        # Prefer exact reuse when both samplings have same number of k-points.
         if !isnothing(kx_wann)
-            # Find segment boundaries in the Wannier kx array (jump > median step)
-            diffs    = diff(kx_wann)
-            med_step = median(diffs)
-            seg_ends = [i for i in eachindex(diffs) if diffs[i] > 2*med_step]
-            seg_bounds = vcat(1, seg_ends .+ 1, length(kx_wann) + 1)  # start indices + sentinel
-            Nseg = length(seg_bounds) - 1
-            X_wann = zeros(length(kx_wann))
-            for i in 1:Nseg
-                i0w = seg_bounds[i]; i1w = seg_bounds[i+1] - 1
-                offset = i == 1 ? 0.0 : sum(path_lengths[1:i-1])
-                X_wann[i0w:i1w] .= offset .+ range(0, path_lengths[i], length = i1w - i0w + 1)
+            if length(kx_wann) == length(X)
+                X_wann = copy(X)
+            else
+                # Segment boundaries in Wannier path: detect resets/non-monotonic steps.
+                # This is robust for files that restart k-distance at each segment.
+                diffs = diff(kx_wann)
+                seg_ends = [i for i in eachindex(diffs) if diffs[i] <= 0]
+                seg_bounds = vcat(1, seg_ends .+ 1, length(kx_wann) + 1)
+                Nseg_wann = length(seg_bounds) - 1
+
+                if Nseg_wann == length(path_lengths)
+                    X_wann = zeros(length(kx_wann))
+                    for i in 1:Nseg_wann
+                        i0w = seg_bounds[i]
+                        i1w = seg_bounds[i + 1] - 1
+                        offset = i == 1 ? 0.0 : sum(path_lengths[1:i-1])
+                        X_wann[i0w:i1w] .= offset .+ range(0, path_lengths[i], length = i1w - i0w + 1)
+                    end
+                else
+                    # Conservative fallback: globally rescale to DFT x-range.
+                    kmin, kmax = extrema(kx_wann)
+                    scale = isapprox(kmax, kmin) ? 0.0 : (last(X) - first(X)) / (kmax - kmin)
+                    X_wann = first(X) .+ (kx_wann .- kmin) .* scale
+                end
             end
         else
             X_wann = X   # fallback: assume same grid


### PR DESCRIPTION
### Motivation

- Correct handling of merged high-symmetry labels and missing automatic labels so x-axis ticks remain meaningful.
- Make Wannier k-space overlays robust to differing k-point samplings and restart/non-monotonic kx segments.
- Improve reliability of band plotting when reusing or rescaling Wannier data to the DFT X grid.

### Description

- Replace a length-based check with `occursin("|", klabels[i])` in `find_path_lengths` to detect merged labels like `"A|B"` correctly.
- Add deterministic fallback label assignment in `plot_bands` that replaces empty labels with `"K1"`, `"K2"`, ... when automatic detection yields blanks.
- Rework Wannier kx → DFT X rescaling in `plot_bands` to: prefer exact reuse when `length(kx_wann) == length(X)`, detect segment boundaries by non-monotonic steps, map each segment if the segment count matches `path_lengths`, and otherwise apply a conservative global linear rescale across the full X range.
- Add clarifying comments and small refactors around the Wannier rescaling logic and label handling.

### Testing

- Ran the repository's automated test suite with `] test` and all tests completed successfully.
- Executed the package's plotting-related unit/integration tests that exercise `plot_bands` and `wann` overlay handling and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4fb0b937883309aa3236d1f02918d)